### PR TITLE
Histo production based on detectors status

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,36 +7,49 @@ From terminal, outside any legend sif container, type
 
 
 # Config entries
-Put here some useful paths:
+Put here some useful paths and info to retrieve data:
 ```bash
     {
         "gamma-src-code": "/lfs/l1/legend/users/calgaro/legend_analysis/legend-gamma-lines-analysis", // where you have located the folder
         "output": "/lfs/l1/legend/users/calgaro/legend_analysis/legend-gamma-lines-analysis/output/2023-09-04/", // where you want to store any fit output
-        "histo-folder": "/lfs/l1/legend/users/calgaro/legend_analysis/legend-gamma-lines-analysis/src/root_files/0_25keV-golden/", // where you can find the generated ROOT files
+        "prodenv": "/lfs/l1/legend/data/public/prodenv/prod-blind/ref/", // folder containing processed data
+        "version": "v01.06", // version of processed data
 ```
 
-Below, you need to provide input for data to read and data to inspect (eg. periods/runs/detector type/cut)
+Below, you need to provide input for which data you want to inspect (eg. periods/runs/detector type/cut)
 ```bash        
         "dataset": {
-            "prodenv": "/lfs/l1/legend/data/public/prodenv/prod-blind/ref/",
-            "version": "v01.06",
-            "comments": ["The user can set the list of periods, runs and detector types ('single','All','BEGe', 'ICPC', 'COAX','PPC' )",
-                        "If they want to study only some detector then set a list [] in the 'detectors' key",
-                        "The user can choose the cut to apply among ['raw',  'LAr AC', 'LAr C']"], 
-            "periods": ["p03", "p04"],
-            "runs": [["r000", "r001"], ["r000"]], // one list of runs for each period
-            "detectors": "BEGe",
-            "cut": "raw"
-        },
+            "periods": ["p03", "p04"], // list of periods to inspect
+            "runs": [["r000", "r001"], ["r000"]], // for each period, list of runs to inspect
+            "status": ["on", "no_psd"], // detectors status to keep in the analysis
+            "detectors": "BEGe", // choose among 'BEGe', 'COAX', 'PPC', 'ICPC', 'All', 'single'
+            "cut": "raw", // choose among 'raw', 'LArC', 'LArAC'
 ```
+In particular, you can build your specific dataset in the following way:
+- _golden_ dataset: `"status": ["on"]`
+- _silver_ dataset: `"status": ["on", "no_psd"]`
+- _bronze_ dataset: `"status": ["on", "no_psd", "ac"]`
+For each dataset, a different set of cuts is applied over flags saved in the skimmed files.
 
-Below, specify entries needed for exposure:
+If you select `"detectors": "All"`, you'll inspect the spectrum given by the sum of counts coming from all detectors. 
+If you select `"detectors": "singe"`, you'll inspect the spectrum of each detector separately. However, the analysis here considers only the K lines because of their higher statistics (useful to perform studies on the spatial distribution of K-40 and K-42 contaminants).
+
+Finally, there is a specific entry for building ROOT files, ie histograms containing the spectra that you can inspect:
 ```bash
-        "exposure": {
-            "comments": ["The user can set the time unit of exposure evaluation ('sec', 'min', 'hour', 'day', 'yr')",
-                    "The user can choose the status of detectors to include in the exposure evaluation among 'on', 'off', 'ac', 'no_psd' or a combination of them."],
-            "time-unit": "yr", 
-            "status": ["on"] // status of detector to take into account
+        
+            "histogram": {
+                "overwrite": true, 
+                "folder": "raw_BEGe", // name of the folder where you want to store the ROOT files; it's created under 'src/root_files/'
+                "bin-width": 1, // bin width in keV
+                "x-min-keV": 0, // minimum in keV of the x-axis of the energy spectrum
+                "x-max-keV": 5000 // maximum in keV of the x-axis of the energy spectrum
         }
-    }  
+    }
 ```
+Select `"overwrite": true` if you want to re-generate the ROOT files (ie overwrite the previous ROOT folder, if exists), otherwise `"overwrite": false` if you want to skip the generation of ROOT files because already done in the past.
+
+# `Src` content
+Apart from the core of the code, here you can find:
+- `gamma-fitter`: folder containing the BAT-C++ Bayesian analysis 
+- `root_files`: folder containing the ROOT files that are produced starting from the processed skimmed files; if not present, this is created the first time you run the code
+- `settings`: folder containing several tools and files produced along the running of the code (ex: exposure values, resolution values, list of available detectors)

--- a/config/config.json
+++ b/config/config.json
@@ -12,6 +12,7 @@
       "detectors": "BEGe",
       "cut": "raw",
       "histogram": {
+        "overwrite": false,
         "folder": "raw_BEGe",
         "bin-width": 1,
         "x-min-keV": 0,

--- a/config/config.json
+++ b/config/config.json
@@ -22,7 +22,6 @@
     "exposure": {
       "comments": ["The user can set the time unit of exposure evaluation ('sec', 'min', 'hour', 'day', 'yr')",
               "The user can choose the status of detectors to include in the exposure evaluation among 'on', 'off', 'ac', 'no_psd' or a combination of them."],
-      "time-unit": "yr",
       "status": ["on"]
     }
 }  

--- a/config/config.json
+++ b/config/config.json
@@ -6,11 +6,11 @@
   "dataset": {
     "periods": ["p03", "p04"],
     "runs": [["r000", "r001"], ["r000"]],
-    "status": ["on"],
+    "status": ["on", "no_psd"],
     "detectors": "BEGe",
     "cut": "raw",
     "histogram": {
-      "overwrite": false,
+      "overwrite": true,
       "folder": "raw_BEGe",
       "bin-width": 1,
       "x-min-keV": 0,

--- a/config/config.json
+++ b/config/config.json
@@ -1,27 +1,20 @@
 {
-    "gamma-src-code": "/lfs/l1/legend/users/calgaro/legend_analysis/legend-gamma-lines-analysis",
-    "output": "/lfs/l1/legend/users/calgaro/legend_analysis/legend-gamma-lines-analysis/output/2023-09-04/",
-    "dataset": {
-      "prodenv": "/lfs/l1/legend/data/public/prodenv/prod-blind/ref/",
-      "version": "v01.06",
-      "comments": ["The user can set the list of periods, runs and detector types ('single','All','BEGe', 'ICPC', 'COAX','PPC' )",
-                "If they want to study only some detector then set a list [] in the 'detectors' key",
-                "The user can choose the cut to apply among ['raw',  'LAr AC', 'LAr C']"], 
-      "periods": ["p03", "p04"],
-      "runs": [["r000", "r001"], ["r000"]],
-      "detectors": "BEGe",
-      "cut": "raw",
-      "histogram": {
-        "overwrite": false,
-        "folder": "raw_BEGe",
-        "bin-width": 1,
-        "x-min-keV": 0,
-        "x-max-keV": 5000
-      }
-    },
-    "exposure": {
-      "comments": ["The user can set the time unit of exposure evaluation ('sec', 'min', 'hour', 'day', 'yr')",
-              "The user can choose the status of detectors to include in the exposure evaluation among 'on', 'off', 'ac', 'no_psd' or a combination of them."],
-      "status": ["on"]
+  "gamma-src-code": "/lfs/l1/legend/users/calgaro/legend_analysis/legend-gamma-lines-analysis",
+  "output": "/lfs/l1/legend/users/calgaro/legend_analysis/legend-gamma-lines-analysis/output/2023-09-04/",
+  "prodenv": "/lfs/l1/legend/data/public/prodenv/prod-blind/ref/",
+  "version": "v01.06",
+  "dataset": {
+    "periods": ["p03", "p04"],
+    "runs": [["r000", "r001"], ["r000"]],
+    "status": ["on"],
+    "detectors": "BEGe",
+    "cut": "raw",
+    "histogram": {
+      "overwrite": false,
+      "folder": "raw_BEGe",
+      "bin-width": 1,
+      "x-min-keV": 0,
+      "x-max-keV": 5000
     }
+  }
 }  

--- a/run-bat.qsub
+++ b/run-bat.qsub
@@ -22,7 +22,7 @@ fi
 cd $2
 
 if [ $4 == 'All' ] || [ $4 == 'BEGe' ] || [ $4 == 'ICPC' ] || [ $4 == 'COAX' ] || [ $4 == 'PPC' ]; then
-    singularity exec /lfs/l1/legend/software/singularity/legendexp_legend-software_latest.sif bash -c "source /usr/local/bin/thisroot.sh && cd $2 && python src/main.py --config $1" &> $OUT_FOLDER/log/$LOGFILE
+    singularity exec /lfs/l1/legend/software/singularity/legendexp_legend-software_latest.sif bash -c "source /usr/local/bin/thisroot.sh && cd $2 && python src/main.py --config $1 --det $4" &> $OUT_FOLDER/log/$LOGFILE
     source ~/.bashrc
     #cd src/gamma-fitter/runGammaAnalysis
     #make runGammaAnalysis &&

--- a/src/get_resolution.py
+++ b/src/get_resolution.py
@@ -13,14 +13,14 @@ pars = 'eres_pars'
 
 def get_resolution(config_file, detectors):
     # retrieve useful info
-    _, _, info, expo, _ = main.return_config_info(config_file)
+    _, _, info, status, _ = main.return_config_info(config_file)
 
-    file_exposure = f'src/settings/exposure_in_kg_{expo[0]}'
-    if isinstance(expo[1],list):
-        for st in expo[1]:
+    file_exposure = f'src/settings/exposure_in_kg_yr'
+    if isinstance(status,list):
+        for st in status:
             file_exposure += f"_{st}" 
-    if isinstance(expo[1], str):
-        file_exposure += f"_{expo[1]}" 
+    if isinstance(status, str):
+        file_exposure += f"_{status}" 
     file_exposure += '.json'
     with open(file_exposure, "r") as file:
         exposure_det = json.load(file)
@@ -40,7 +40,7 @@ def get_resolution(config_file, detectors):
             full_status_map = JsonDB(map_file).on(
                 timestamp=first_timestamp, system="geds"
             )["analysis"]
-            status_map = {key: value for key, value in full_status_map.items() if value.get('usability') in expo[1]}
+            status_map = {key: value for key, value in full_status_map.items() if value.get('usability') in status}
             all_detectors = [det for det in status_map.keys() if "S" not in det]
             map_file = os.path.join(info[0], info[4], "inputs/hardware/configuration/channelmaps")
             channel_map = JsonDB(map_file).on(timestamp=first_timestamp)

--- a/src/main.py
+++ b/src/main.py
@@ -53,15 +53,15 @@ def return_config_info(config_file):
     histo_overwrite = config["dataset"]["histogram"]["overwrite"]
     histo_info = [histo_folder, histo_bin_width, histo_x_min, histo_x_max, histo_overwrite]
     # general info
-    prodenv = config["dataset"]["prodenv"]
+    prodenv = config["prodenv"]
+    version = config["version"]
     periods = config["dataset"]["periods"]
     runs = config["dataset"]["runs"]
     detectors = config["dataset"]["detectors"]
-    version = config["dataset"]["version"]
     cut = config["dataset"]["cut"]
     info = [prodenv, periods, runs, detectors, version, cut]
     # exposure info
-    status = config["exposure"]["status"].split() if isinstance(config["exposure"]["status"], str) else config["exposure"]["status"]
+    status = config["dataset"]["status"].split() if isinstance(config["dataset"]["status"], str) else config["dataset"]["status"]
 
     return gamma_src_code, output, info, status, histo_info
         

--- a/src/main.py
+++ b/src/main.py
@@ -118,7 +118,7 @@ def main():
     
     # create histograms with run and periods of interest if specified or if not already present
     if histo_info[4] is True or (histo_info[4] is False and not os.path.isdir(os.path.join('src/root_files', histo_info[0]))):
-        get_histos(config_file)
+        make_histos(config_file)
         logger_expo.debug(f"New histograms were created in {os.path.join('src/root_files', histo_info[0])}")
     
     #check periods and runs set by the user

--- a/src/main.py
+++ b/src/main.py
@@ -50,7 +50,8 @@ def return_config_info(config_file):
     histo_bin_width = config["dataset"]["histogram"]["bin-width"]
     histo_x_min = config["dataset"]["histogram"]["x-min-keV"]
     histo_x_max = config["dataset"]["histogram"]["x-max-keV"]
-    histo_info = [histo_folder, histo_bin_width, histo_x_min, histo_x_max]
+    histo_overwrite = config["dataset"]["histogram"]["overwrite"]
+    histo_info = [histo_folder, histo_bin_width, histo_x_min, histo_x_max, histo_overwrite]
     # general info
     prodenv = config["dataset"]["prodenv"]
     periods = config["dataset"]["periods"]
@@ -117,10 +118,11 @@ def main():
         logger_expo.debug(f"{info[3]} is not an available detector. Try among '['All',  'single', 'BEGe', 'COAX', 'ICPC', 'PPC']'")
         return
     
-    # create histograms with run and periods of interest
-    get_histos(config_file)
-    logger_expo.debug(f"Histograms were created in {os.path.join('src/root_files', histo_info[0])}")
-        
+    # create histograms with run and periods of interest if specified or if not already present
+    if histo_info[4] is True or (histo_info[4] is False and not os.path.isdir(os.path.join('src/root_files', histo_info[0]))):
+        get_histos(config_file)
+        logger_expo.debug(f"New histograms were created in {os.path.join('src/root_files', histo_info[0])}")
+    
     #check periods and runs set by the user
     list_avail = []
 

--- a/src/main.py
+++ b/src/main.py
@@ -61,11 +61,9 @@ def return_config_info(config_file):
     cut = config["dataset"]["cut"]
     info = [prodenv, periods, runs, detectors, version, cut]
     # exposure info
-    exposure_time_unit = config["exposure"]["time-unit"]
     status = config["exposure"]["status"].split() if isinstance(config["exposure"]["status"], str) else config["exposure"]["status"]
-    expo = [exposure_time_unit, status]
 
-    return gamma_src_code, output, info, expo, histo_info
+    return gamma_src_code, output, info, status, histo_info
         
 def get_histo(gamma_src_code, histo_folder, version, result_dict, detectors, cut):
     """Combine single histograms."""
@@ -97,7 +95,7 @@ def main():
 
 
     # ...reading the config file...
-    gamma_src_code, output, info, expo, histo_info = return_config_info(config_file)
+    gamma_src_code, output, info, status, histo_info = return_config_info(config_file)
     logger_expo.debug("...inspected!")
     
     #check version set by the user
@@ -149,7 +147,7 @@ def main():
         result_dict[p] = run_avail   
 
     #create json file with the exposure
-    _ = get_exposure.main(expo[0], str(result_dict), expo[1], info[0], info[4])
+    _ = get_exposure.main("yr", str(result_dict), status, info[0], info[4])
       
     if info[3] == "single":
         histo_name = det


### PR DESCRIPTION
We can build the golden (ON) or silver (ON+NO_PSD) or bronze (ON+NO_PSD+AC) histograms by simply providing a list of `status` in the config file to keep when selecting data from skimmed files.

The config file was re-arranged in a more simple form.

In particular, the used flags in building the correct datasets, are mainly the following:
- `is_valid_channel == True` if we need only ON detectors, ie we want to remove the AC ones
- `is_usable_aoe == True` if we want to keep detectors for which the PSD is available
