### PR TITLE
Posterior check + prior range widening

### DIFF
--- a/run-bat.qsub
+++ b/run-bat.qsub
@@ -34,7 +34,7 @@ if [ $4 == 'All' ] || [ $4 == 'BEGe' ] || [ $4 == 'ICPC' ] || [ $4 == 'COAX' ] |
         E_max="$(grep -oP '"energy-max-keV": \K\d+' $1)"
         E_step="$(grep -oP '"energy-step-keV": \K\d+' $1)"
         E_window="$(grep -oP '"fit-window-width-keV": \K\d+' $1)"
-        src/gamma-fitter/runGammaAnalysis $5 $4 false $6 $E_min $E_max $E_step $E_window &>> $OUT_FOLDER/log/$LOGFILE
+        src/gamma-fitter/runGammaAnalysis $5 $4 false $6 $E_min $E_max $E_step $E_window $OUT_FOLDER/$4 &>> $OUT_FOLDER/log/$LOGFILE
     fi
 else
     singularity exec /lfs/l1/legend/software/singularity/legendexp_legend-software_latest.sif bash -c "source /usr/local/bin/thisroot.sh && cd $2 && python src/main.py --config $1 --det $5" &> $OUT_FOLDER/log/$LOGFILE

--- a/run.sh
+++ b/run.sh
@@ -1,10 +1,5 @@
 #!/usr/bin/env bash
 
-# Check if the folder is not empty; then, remove content
-if [ -n "$(ls -A tmp/)" ]; then
-  rm tmp/*
-fi
-
 gamma_src_code="$(grep -oP '(?<="gamma-src-code": ")[^"]*' $1)"
 output_folder="$(grep -oP '(?<="output": ")[^"]*' $1)"
 

--- a/src/gamma-fitter/GammaLineFit.cxx
+++ b/src/gamma-fitter/GammaLineFit.cxx
@@ -117,6 +117,8 @@ int GammaLineFit::Fit( TString name, vector<double> lines, pair<double,double> r
 {
   Fit(lines,range,backgroundType,linePosPrior,fwhmPrior,precision);
 
+  // qui si puo' insterire un for per il check delle posterior - ed eventualmente allargare il range dando in input un parametro in Fit(...)
+
   //! provide log output
   vector<double> bestFitPars      = fHistFitter->GetBestFitParameters();
   vector<double> bestFitParErrors = fHistFitter->GetBestFitParameterErrors();
@@ -175,17 +177,11 @@ int GammaLineFit::Fit( TString name, vector<double> lines, pair<double,double> r
     low = intensity.GetQuantile(0.16);
     high = intensity.GetQuantile(0.84);
 
-  //************************************************************************
-    if(low>0 and mode>0) {  
-      foutput[name_fit]["fit_parameters"]["line"][fFitFunction->GetParName(nBkgPars+3*i+2) + string("_in_cts")]["mode"] = mode;
-      foutput[name_fit]["fit_parameters"]["line"][fFitFunction->GetParName(nBkgPars+3*i+2) + string("_in_cts")]["range_min"] = low;
-      foutput[name_fit]["fit_parameters"]["line"][fFitFunction->GetParName(nBkgPars+3*i+2) + string("_in_cts")]["range_max"] = high;
-      foutput[name_fit]["fit_parameters"]["line"][fFitFunction->GetParName(nBkgPars+3*i+2) + string("_in_cts")]["comments"] = "at 68%";
-    } 
-    else {
-      foutput[name_fit]["fit_parameters"]["line"][fFitFunction->GetParName(nBkgPars+3*i+2) + string("_in_cts")]["upper_limit"] = intensity.GetQuantile(0.90);
-      foutput[name_fit]["fit_parameters"]["line"][fFitFunction->GetParName(nBkgPars+3*i+2) + string("_in_cts")]["comments"] = "at 90%";
-    }
+    // save global mode, central 68% intervcal and upper limit
+    foutput[name_fit]["fit_parameters"]["line"][fFitFunction->GetParName(nBkgPars+3*i+2) + string("_in_cts")]["mode"] = mode;
+    foutput[name_fit]["fit_parameters"]["line"][fFitFunction->GetParName(nBkgPars+3*i+2) + string("_in_cts")]["range_min"] = low;
+    foutput[name_fit]["fit_parameters"]["line"][fFitFunction->GetParName(nBkgPars+3*i+2) + string("_in_cts")]["range_max"] = high;
+    foutput[name_fit]["fit_parameters"]["line"][fFitFunction->GetParName(nBkgPars+3*i+2) + string("_in_cts")]["upper_limit"] = intensity.GetQuantile(0.90);
   }
   foutput[name_fit]["fit_parameters"]["p-value"] = fHistFitter->GetPValue();
   

--- a/src/gamma-fitter/GammaLineFit.h
+++ b/src/gamma-fitter/GammaLineFit.h
@@ -55,12 +55,12 @@ public:
     void SetRes(TF1* res) { fRes = res; };
 
     //! Methods
-    int Fit(vector<double> lines, pair<double, double> range,
+    int Fit(vector<double> lines, pair<double, double> range, std::vector<int> rangePrior,
             GammaBackground backgroundType = kLinear,
             double linePosPrior = 0.2, // keV
             double fwhmPrior = 0.2,    // keV
             BCEngineMCMC::Precision precision = BCEngineMCMC::kLow);
-    int Fit(TString name, vector<double> lines, pair<double, double> range,
+    int Fit(TString name, vector<double> lines, pair<double, double> range, std::vector<int> rangePrior,
             GammaBackground backgroundType = kLinear,
             double linePosPrior = 0.2, // keV
             double fwhmPrior = 0.2,    // keV

--- a/src/gamma-fitter/Makefile
+++ b/src/gamma-fitter/Makefile
@@ -21,7 +21,8 @@ LIBS := $(shell bat-config --libs)
 CXXFLAGS += -I/lfs/l1/legend/software/root/v06.14/include # or -I/opt/root/include in the container
 
 # Source files
-CXXSRCS = GammaLineFit.cxx
+CXXSRCS = GammaLineFit.cxx \
+          Utils.h
 PRGSRCS = runGammaAnalysis.cxx
 
 # Object files

--- a/src/gamma-fitter/Utils.cxx
+++ b/src/gamma-fitter/Utils.cxx
@@ -1,0 +1,151 @@
+#include "Utils.h"
+#include <iostream>
+#include <fstream>
+#include <vector>
+#include <string>
+#include "../settings/json.hpp"
+using namespace nlohmann;
+#include <sys/stat.h>
+
+bool fileExists(const std::string& filePath) {
+    struct stat buffer;
+    return (stat(filePath.c_str(), &buffer) == 0);
+}
+
+
+void write_to_json(std::string filePath, std::string name_fit, ordered_json foutput) {
+/*  ---> this part is having problems, adding too '}}' at the eof
+  // check if the json file aready exists
+  if (fileExists(filePath)) {
+    std::fstream json_file;
+    json_file.open(filePath, std::ios::in | std::ios::out);
+    // parse the existing JSON from the file
+    ordered_json foutput_tot = json::parse(json_file);
+    // check if the 'name_fit' key already exists; if so, remove it
+    //if ( foutput_tot.find(name_fit) != foutput_tot.end() ) {
+    //  foutput_tot.erase(name_fit);
+    //}
+    // add the new key
+    //foutput_tot.update(foutput); //, true);
+    foutput_tot[name_fit] = foutput;
+    // the array is empty again
+    json_file.clear();
+    // let's write from the top of the file
+    json_file.seekp(0);
+    // set indent to 2
+    json_file << foutput_tot.dump(2);
+    json_file.close();
+  }
+  // json file does not exist, let's write in it for the first time!
+  else{
+    std::fstream json_file;
+    json_file.open(filePath, std::ios::out);
+    json foutput_tot;
+    foutput_tot[name_fit] = foutput;
+    json_file << foutput_tot.dump(2);
+    json_file.close();
+  }
+*/
+
+  std::fstream json_file;
+  json_file.open(filePath, std::ios::out);
+  json foutput_tot;
+  foutput_tot[name_fit] = foutput;
+  json_file << foutput_tot.dump(2);
+  json_file.close();
+
+  std::ifstream jsonFile(filePath);
+  if (jsonFile.is_open()) {
+    std::string fileContent((std::istreambuf_iterator<char>(jsonFile)), std::istreambuf_iterator<char>());
+    std::cout << "File Content:\n" << fileContent << std::endl;
+  } else {
+    std::cerr << "Error: Could not open file for reading." << std::endl;
+  }
+}
+
+
+std::vector<int> CheckPosterior(std::string fit_name, std::string path_to_output, int bkg) {
+  // bkg = 0,1,2 - the posterior check for the step background is still not implemented
+  // The idea is to perform the check for the peak search analysis only, where we don't expect to fit with a step function
+  
+  std::string name = path_to_output + "/histo_marginalized." + fit_name + ".root";
+  TFile *file = new TFile(name.c_str()); 
+
+  // E0 marginalzied posterior histogram
+  std::string histo_E0 = "h1_histo_fitter_model_parameter_intensity0";
+  TH1D *hE0 = (TH1D*) file->Get(histo_E0.c_str());
+
+  // p0 marginalzied posterior histogram
+  std::string histo_p0 = "h1_histo_fitter_model_parameter_par00";
+  TH1D *hp0 = (TH1D*) file->Get(histo_p0.c_str());
+
+  // p1 marginalzied posterior histogram (if exists)
+  std::string histo_p1 = "h1_histo_fitter_model_parameter_par1";
+  TH1D *hp1 = new TH1D();
+  if ( bkg>=1 ) { hp1 = (TH1D*) file->Get(histo_p1.c_str()); }
+
+  // p2 marginalzied posterior histogram (if exists)
+  std::string histo_p2 = "h1_histo_fitter_model_parameter_par2";
+  TH1D *hp2 = new TH1D();
+  if ( bkg==2 ) { hp2 = (TH1D*) file->Get(histo_p2.c_str()); }
+  
+  // study of the 1st and last bin content
+  int p0BinMax=0, p1BinMax=0, p2BinMax=0;
+  p0BinMax = hp0->GetMaximumBin();
+  if ( bkg>=1 ) {
+    p1BinMax = hp1->GetMaximumBin();
+    if ( bkg==2 ) { p2BinMax = hp2->GetMaximumBin(); }
+  }
+
+  // Get bins that correspond to 5% of all bins
+  int tot_bins = hp0->GetNbinsX();
+  int bin_5_perc = tot_bins*0.05;
+
+  // Mean of first 5% bins 
+  double p0FirstSum=0, p1FirstSum=0, p2FirstSum=0;
+  double p0FirstMean=0, p1FirstMean=0, p2FirstMean=0;
+  for ( int i=1; i<=bin_5_perc; i++ ) {
+    p0FirstSum += hp0->GetBinContent(i);
+    if ( bkg>=1 ) {
+      p1FirstSum += hp1->GetBinContent(i);
+      if ( bkg==2 ) { p2FirstSum += hp2->GetBinContent(i); }
+    }
+  }
+  p0FirstMean = p0FirstSum/bin_5_perc;
+  if ( bkg>=1 ) {
+    p1FirstMean = p1FirstSum/bin_5_perc;
+    if ( bkg==2 ) { p2FirstMean = p2FirstSum/bin_5_perc; }
+  }
+
+  // Mean of last 5% bins 
+  double p0LastSum=0, p1LastSum=0, p2LastSum=0;
+  double p0LastMean=0, p1LastMean=0, p2LastMean=0;
+  for ( int i=(hp0->GetNbinsX())-(bin_5_perc-1); i<=hp0->GetNbinsX(); i++ ) { p0LastSum += hp0->GetBinContent(i); }
+  if ( bkg>=1 ) { 
+    for ( int i=(hp1->GetNbinsX())-(bin_5_perc-1); i<=hp1->GetNbinsX(); i++ ) { p1LastSum += hp1->GetBinContent(i); } }
+    if ( bkg==2 ) { for ( int i=(hp2->GetNbinsX())-(bin_5_perc-1); i<=hp2->GetNbinsX(); i++ ) { p2LastSum += hp2->GetBinContent(i); }
+  }
+  p0LastMean = p0LastSum/bin_5_perc;
+  if ( bkg>=1 ) {
+    p1LastMean = p1LastSum/bin_5_perc;
+    if ( bkg==2 ) { p2LastMean = p2LastSum/bin_5_perc; }
+  }
+
+  double p0FirstBin=0, p1FirstBin=0, p2FirstBin=0;
+  double p0LastBin=0, p1LastBin=0, p2LastBin=0;
+  p0FirstBin = hp0->GetBinContent(1);
+  p0LastBin = hp0->GetBinContent(hp0->GetNbinsX());
+  p1FirstBin = hp1->GetBinContent(1);
+  p1LastBin = hp1->GetBinContent(hp1->GetNbinsX());
+  p2FirstBin = hp2->GetBinContent(0); p2LastBin = hp2->GetBinContent(hp2->GetNbinsX()); 
+  double E0LastBin = hE0->GetBinContent(hE0->GetNbinsX());
+
+  int ck0=0, ck1=0, ck2=0, ckE0=0;
+  if ( p0FirstMean/(hp0->GetBinContent(p0BinMax))>0.1 || p0LastMean/(hp0->GetBinContent(p0BinMax))>0.1 ) { ck0 = 1; }
+  if ( p1FirstMean/(hp1->GetBinContent(p1BinMax))>0.1 || p1LastMean/(hp1->GetBinContent(p1BinMax))>0.1 ) { ck1 = 1; }
+  if ( p2FirstMean/(hp2->GetBinContent(p2BinMax))>0.1 || p2LastMean/(hp2->GetBinContent(p2BinMax))>0.1 ) { ck2 = 1; }
+  if ( E0LastBin!=0 ) { ckE0 = 1; }
+  std::vector<int> results = {ck0, ck1, ck2, ckE0};
+      
+  return results;
+}

--- a/src/gamma-fitter/Utils.h
+++ b/src/gamma-fitter/Utils.h
@@ -1,0 +1,20 @@
+#include <BAT/BCModel.h>
+#include <BAT/BCMath.h>
+#include <BAT/BCMTF.h>
+#include <BAT/BCDataSet.h>
+#include <BAT/BCDataPoint.h>
+
+#include <TFile.h>
+#include <TMath.h>
+
+#include <string>
+#include <vector>
+#include "../settings/json.hpp"
+using namespace nlohmann;
+#include <sys/stat.h>
+
+#pragma once
+
+        bool fileExists(const std::string& filePath); // check if a file exists, given the path
+        void write_to_json(std::string filePath, std::string name_fit, ordered_json foutput); // write output to json file
+	std::vector<int> CheckPosterior(std::string fit_name, std::string E0, int bkg); // check posterior pdfs

--- a/src/gamma-fitter/runGammaAnalysis.cxx
+++ b/src/gamma-fitter/runGammaAnalysis.cxx
@@ -1,6 +1,7 @@
 // MODELS
 #include "GammaFitFunctions.h"
 #include "GammaLineFit.h"
+#include "Utils.h"
 
 // ROOT
 #include <TMath.h>
@@ -12,45 +13,48 @@
 #include <string>
 #include <iomanip> 
 #include <iostream>
+#include <vector>
+#include <algorithm>
 
 
 void GammaAnalysis( TString name, TH1D* histo, TF1* res, TString outputDir )
 {
   std::GammaLineFit fitter(name, histo, res, outputDir);
+  std::vector<int> prior_range = {1,1,1,1};
 
   //K lines
-  fitter.Fit("K42_1525", {1524.7}, {1505.,1545.}, std::kLinear, 0.5, 0.2, BCEngineMCMC::kMedium); // 18.1%, kStep?, pos priot 0.2 -> 0.5
-  fitter.Fit("K40_1461",    {1460.8}, {1441.,1481.}, std::kStep,   0.2, 0.2, BCEngineMCMC::kMedium); // 10.7%, kStep?
+  fitter.Fit("K42_1525", {1524.7}, {1505.,1545.}, prior_range, std::kLinear, 0.5, 0.2, BCEngineMCMC::kMedium); // 18.1%, kStep?, pos priot 0.2 -> 0.5
+  fitter.Fit("K40_1461",    {1460.8}, {1441.,1481.}, prior_range, std::kStep,   0.2, 0.2, BCEngineMCMC::kMedium); // 10.7%, kStep?
   //Co lines
-  fitter.Fit("Co60_1332",   {1332.5}, {1313.,1353.}, std::kLinear, 0.2, 0.2, BCEngineMCMC::kMedium); //100.0%
-  fitter.Fit("Co60_1173",   {1173.2}, {1153.,1193.}, std::kLinear, 0.2, 0.2, BCEngineMCMC::kMedium); // 99.9%
+  fitter.Fit("Co60_1332",   {1332.5}, {1313.,1353.}, prior_range, std::kLinear, 0.2, 0.2, BCEngineMCMC::kMedium); //100.0%
+  fitter.Fit("Co60_1173",   {1173.2}, {1153.,1193.}, prior_range, std::kLinear, 0.2, 0.2, BCEngineMCMC::kMedium); // 99.9%
   //Th chain
-  fitter.Fit("Ac228_911" ,  { 911.2}, { 891., 931.}, std::kLinear, 0.2, 0.2, BCEngineMCMC::kMedium); // 25.8%
-  fitter.Fit("Ac228_1588" ,  { 1588.2}, { 1568., 1608.}, std::kLinear, 0.2, 0.2, BCEngineMCMC::kMedium); // 3.2%
-  //fitter.Fit("Ac228_969" ,  { 969.0}, { 949., 989.}, std::kLinear, 0.2, 0.2, BCEngineMCMC::kMedium); // 15.8%, -> in overlap!
-  //fitter.Fit("Ac228_338" ,  { 338.3}, { 318., 348.}, std::kQuadratic); // 11.3% check coax!!                   -> in overlap!
-  fitter.Fit("Bi212_727",   { 727.3}, { 707., 747.}, std::kLinear, 0.2, 0.2, BCEngineMCMC::kMedium); //  6.7%
-  fitter.Fit("Tl208_2614",  {2614.5}, {2595.,2635.}, std::kFlat,   0.2, 0.2, BCEngineMCMC::kMedium); // 99.8%
-  fitter.Fit("Tl208_583",   { 583.2}, { 563., 603.}, std::kLinear, 0.2, 0.2, BCEngineMCMC::kMedium); // 85.0% 
-  fitter.Fit("Tl208_861",   { 860.6}, { 841., 881.}, std::kLinear, 0.2, 0.2, BCEngineMCMC::kMedium); // 12.5% 
+  fitter.Fit("Ac228_911" ,  { 911.2}, { 891., 931.}, prior_range, std::kLinear, 0.2, 0.2, BCEngineMCMC::kMedium); // 25.8%
+  fitter.Fit("Ac228_1588" ,  { 1588.2}, { 1568., 1608.}, prior_range, std::kLinear, 0.2, 0.2, BCEngineMCMC::kMedium); // 3.2%
+  //fitter.Fit("Ac228_969" ,  { 969.0}, { 949., 989.}, prior_range, std::kLinear, 0.2, 0.2, BCEngineMCMC::kMedium); // 15.8%, -> in overlap!
+  //fitter.Fit("Ac228_338" ,  { 338.3}, { 318., 348.}, prior_range, std::kQuadratic); // 11.3% check coax!!                   -> in overlap!
+  fitter.Fit("Bi212_727",   { 727.3}, { 707., 747.}, prior_range, std::kLinear, 0.2, 0.2, BCEngineMCMC::kMedium); //  6.7%
+  fitter.Fit("Tl208_2614",  {2614.5}, {2595.,2635.}, prior_range, std::kFlat,   0.2, 0.2, BCEngineMCMC::kMedium); // 99.8%
+  fitter.Fit("Tl208_583",   { 583.2}, { 563., 603.}, prior_range, std::kLinear, 0.2, 0.2, BCEngineMCMC::kMedium); // 85.0% 
+  fitter.Fit("Tl208_861",   { 860.6}, { 841., 881.}, prior_range, std::kLinear, 0.2, 0.2, BCEngineMCMC::kMedium); // 12.5% 
   //U chain
-  fitter.Fit("Pa234m_1001", {1001.0}, { 981.,1021.}, std::kLinear,    0.2, 0.2, BCEngineMCMC::kMedium); //  0.8% 
-  fitter.Fit("Pb214_352",   { 351.9}, { 332., 372.}, std::kQuadratic, 0.2, 0.2, BCEngineMCMC::kMedium); // 35.6%
-  fitter.Fit("Pb214_295",   { 295.2}, { 275., 315.}, std::kQuadratic, 0.2, 0.2, BCEngineMCMC::kMedium); // 35.6%
-  fitter.Fit("Bi214_609",   { 609.3}, { 589., 629.}, std::kLinear,    0.2, 0.2, BCEngineMCMC::kMedium); // 45.5%
-  fitter.Fit("Bi214_1378",   { 1377.7}, { 1358., 1398.}, std::kLinear, 0.2, 0.2, BCEngineMCMC::kMedium); //  4%
-  fitter.Fit("Bi214_1730" ,  { 1729.6}, { 1710., 1750.}, std::kLinear, 0.2, 0.2, BCEngineMCMC::kMedium); // 2.9%
-  fitter.Fit("Bi214_1764",  {1764.5}, {1744.,1784.}, std::kLinear,    0.2, 0.2, BCEngineMCMC::kMedium); // 15.3%
-  //fitter.Fit("Bi214_1120",  {1120.3}, {1100.,1140.}, std::kLinear,    0.2, 0.2, BCEngineMCMC::kMedium); // 14.9% -> in overlap!
-  fitter.Fit("Bi214_1238",  {1238.1}, {1218.,1258.}, std::kLinear,    0.2, 0.2, BCEngineMCMC::kMedium); //  5.8%
-  fitter.Fit("Bi214_2204",  {2204.1}, {2184.,2224.}, std::kFlat,      0.2, 0.2, BCEngineMCMC::kMedium); //  4.9%  
-  fitter.Fit("Bi214_2448",   { 2447.9}, { 2428., 2468.}, std::kFlat, 0.2, 0.2, BCEngineMCMC::kMedium); //  1.5%
+  fitter.Fit("Pa234m_1001", {1001.0}, { 981.,1021.}, prior_range, std::kLinear,    0.2, 0.2, BCEngineMCMC::kMedium); //  0.8% 
+  fitter.Fit("Pb214_352",   { 351.9}, { 332., 372.}, prior_range, std::kQuadratic, 0.2, 0.2, BCEngineMCMC::kMedium); // 35.6%
+  fitter.Fit("Pb214_295",   { 295.2}, { 275., 315.}, prior_range, std::kQuadratic, 0.2, 0.2, BCEngineMCMC::kMedium); // 35.6%
+  fitter.Fit("Bi214_609",   { 609.3}, { 589., 629.}, prior_range, std::kLinear,    0.2, 0.2, BCEngineMCMC::kMedium); // 45.5%
+  fitter.Fit("Bi214_1378",   { 1377.7}, { 1358., 1398.}, prior_range, std::kLinear, 0.2, 0.2, BCEngineMCMC::kMedium); //  4%
+  fitter.Fit("Bi214_1730" ,  { 1729.6}, { 1710., 1750.}, prior_range, std::kLinear, 0.2, 0.2, BCEngineMCMC::kMedium); // 2.9%
+  fitter.Fit("Bi214_1764",  {1764.5}, {1744.,1784.}, prior_range, std::kLinear,    0.2, 0.2, BCEngineMCMC::kMedium); // 15.3%
+  //fitter.Fit("Bi214_1120",  {1120.3}, {1100.,1140.}, prior_range, std::kLinear,    0.2, 0.2, BCEngineMCMC::kMedium); // 14.9% -> in overlap!
+  fitter.Fit("Bi214_1238",  {1238.1}, {1218.,1258.}, prior_range, std::kLinear,    0.2, 0.2, BCEngineMCMC::kMedium); //  5.8%
+  fitter.Fit("Bi214_2204",  {2204.1}, {2184.,2224.}, prior_range, std::kFlat,      0.2, 0.2, BCEngineMCMC::kMedium); //  4.9%  
+  fitter.Fit("Bi214_2448",   { 2447.9}, { 2428., 2468.}, prior_range, std::kFlat, 0.2, 0.2, BCEngineMCMC::kMedium); //  1.5%
   //overlap
-  fitter.Fit("e+e-_Kr85_514",      { 511.0, 514.0}, { 491., 534.}, std::kLinear,    0.2, 0.2, BCEngineMCMC::kMedium); // 0.4%
-  fitter.Fit("Pb212_239_Pb214_242",{ 238.6, 242.0}, { 218., 262.}, std::kQuadratic, 0.2, 0.2, BCEngineMCMC::kMedium); // 43.6%,  7.3%
-  fitter.Fit("Ac228_338_Pb214_352",{ 338.3, 351.9}, { 318., 372.}, std::kQuadratic, 0.2, 0.2, BCEngineMCMC::kMedium); // 11.3%, 35.6%
-  fitter.Fit("Ac228_965_Ac228_969",{ 964.8, 969.0}, { 945., 989.}, std::kLinear, 0.2, 0.2, BCEngineMCMC::kMedium); // 5%, 25.8%
-  fitter.Fit("Bi214_1120_Zn65_1125",  { 1120.3, 1125.0}, { 1100.,1145.}, std::kLinear,    0.2, 0.2, BCEngineMCMC::kMedium); // 14.9%, ?%
+  fitter.Fit("e+e-_Kr85_514",      { 511.0, 514.0}, { 491., 534.}, prior_range, std::kLinear,    0.2, 0.2, BCEngineMCMC::kMedium); // 0.4%
+  fitter.Fit("Pb212_239_Pb214_242",{ 238.6, 242.0}, { 218., 262.}, prior_range, std::kQuadratic, 0.2, 0.2, BCEngineMCMC::kMedium); // 43.6%,  7.3%
+  fitter.Fit("Ac228_338_Pb214_352",{ 338.3, 351.9}, { 318., 372.}, prior_range, std::kQuadratic, 0.2, 0.2, BCEngineMCMC::kMedium); // 11.3%, 35.6%
+  fitter.Fit("Ac228_965_Ac228_969",{ 964.8, 969.0}, { 945., 989.}, prior_range, std::kLinear, 0.2, 0.2, BCEngineMCMC::kMedium); // 5%, 25.8%
+  fitter.Fit("Bi214_1120_Zn65_1125",  { 1120.3, 1125.0}, { 1100.,1145.}, prior_range, std::kLinear,    0.2, 0.2, BCEngineMCMC::kMedium); // 14.9%, ?%
 
 }
 
@@ -59,14 +63,15 @@ void GammaAnalysis( TString name, TH1D* histo, TF1* res, TString outputDir )
 void GammaAnalysisSingle( TString name, TH1D* histo, TF1* res, TString outputDir )
 {
   std::GammaLineFit fitter(name, histo, res, outputDir);
+  std::vector<int> prior_range = {1,1,1,1};
 
-  fitter.Fit("K42_1525", {1524.7}, {1505.,1545.}, std::kLinear, 0.5, 0.2, BCEngineMCMC::kMedium); // 18.1%, kStep?, pos priot 0.2 -> 0.5
-  fitter.Fit("K40_1461",    {1460.8}, {1441.,1481.}, std::kStep,   0.2, 0.2, BCEngineMCMC::kMedium); // 10.7%, kStep?
+  fitter.Fit("K42_1525", {1524.7}, {1505.,1545.}, prior_range, std::kLinear, 0.5, 0.2, BCEngineMCMC::kMedium); // 18.1%, kStep?, pos priot 0.2 -> 0.5
+  fitter.Fit("K40_1461",    {1460.8}, {1441.,1481.}, prior_range, std::kStep,   0.2, 0.2, BCEngineMCMC::kMedium); // 10.7%, kStep?
 }
 
 
 
-void PeakSearchAnalysis( TString name, TH1D* histo, TF1* res, TString outputDir, double min_E, double max_E, double step, double fit_window )
+void PeakSearchAnalysis( TString name, TH1D* histo, TF1* res, TString outputDir, double min_E, double max_E, double step, double fit_window, std::string output_path )
 {
   std::GammaLineFit fitter(name, histo, res, outputDir);
 
@@ -74,11 +79,42 @@ void PeakSearchAnalysis( TString name, TH1D* histo, TF1* res, TString outputDir,
     std::ostringstream stream;
     stream << std::fixed << std::setprecision(1) << E0;
     std::string fit_name = stream.str();
-    double low_edge = E0-fit_window/2;
-    double upp_edge = E0+fit_window/2;
-    if (E0 <= 500)            { fitter.Fit(fit_name, {E0}, {low_edge, upp_edge}, std::kQuadratic, 0, 0, BCEngineMCMC::kMedium); }
-    if (E0 > 500 && E0<=2000) { fitter.Fit(fit_name, {E0}, {low_edge, upp_edge}, std::kLinear, 0, 0, BCEngineMCMC::kMedium); }
-    if (E0 >2000)             { fitter.Fit(fit_name, {E0}, {low_edge, upp_edge}, std::kFlat, 0, 0, BCEngineMCMC::kMedium); }
+    
+    // some initial values
+    bool foundOne = true;
+    std::vector<int> prior_range = {1,1,1,1};
+    int bkg = 0;
+
+    // we exit the while loop once, for a given energy, the posteriors are ok
+    while ( foundOne = true ) {
+      double low_edge = E0-fit_window/2;
+      double upp_edge = E0+fit_window/2;
+      bool cond1 = (E0 <= 200);
+      bool cond2 = (E0 > 200 && E0<= 2000);
+      bool cond3 = (E0 >2000);
+
+      // fit 
+      if (cond1) { fitter.Fit(fit_name, {E0}, {low_edge, upp_edge}, prior_range, std::kQuadratic, 0, 0, BCEngineMCMC::kMedium); bkg = 2; }
+      if (cond2) { fitter.Fit(fit_name, {E0}, {low_edge, upp_edge}, prior_range, std::kLinear, 0, 0, BCEngineMCMC::kMedium);    bkg = 1; }
+      if (cond3) { fitter.Fit(fit_name, {E0}, {low_edge, upp_edge}, prior_range, std::kFlat, 0, 0, BCEngineMCMC::kMedium);      bkg = 0; }
+
+      // let's check posteriors!
+      // --- if a posterior is bad, then post_check=1 (otherwise =0)
+      std::vector<int> post_check = CheckPosterior(fit_name, output_path, bkg);
+      int post_check_len = post_check.size();
+
+      // --- check if all posteriors are =0
+      bool all_zeros = std::all_of(post_check.begin(), post_check.end(), [](int element) { return element == 0; });
+      if ( all_zeros ) { std::cout << "Posteriors are ok:)" << std::endl; break; }
+      // --- if not, enlarge prior fit range for bad posteriors
+      else {
+        int index = 0;
+        while ( index < post_check_len ) {
+           if ( post_check.at(index) == 1 ) { prior_range[index] = prior_range.at(index)+3; }
+           index++;
+        }
+      }
+    }
   }
 }
 
@@ -114,7 +150,8 @@ int main (int argc, char ** argv)
         double max_E = std::stod(argv[6]);
         double step  = std::stod(argv[7]);
         double fit_window = std::stod(argv[8]);
-        PeakSearchAnalysis("histo" , histo, f_res, outputDir, min_E, max_E, step, fit_window); 
+        std::string output_path = argv[9];
+        PeakSearchAnalysis("histo" , histo, f_res, outputDir, min_E, max_E, step, fit_window, output_path); 
     }
   }
   

--- a/src/gamma-fitter/runGammaAnalysis.cxx
+++ b/src/gamma-fitter/runGammaAnalysis.cxx
@@ -76,9 +76,9 @@ void PeakSearchAnalysis( TString name, TH1D* histo, TF1* res, TString outputDir,
     std::string fit_name = stream.str();
     double low_edge = E0-fit_window/2;
     double upp_edge = E0+fit_window/2;
-    if (E0 <= 500)            { fitter.Fit(fit_name, {E0}, {low_edge, upp_edge}, std::kQuadratic, 0.2, 0.2, BCEngineMCMC::kMedium); }
-    if (E0 > 500 && E0<=2000) { fitter.Fit(fit_name, {E0}, {low_edge, upp_edge}, std::kLinear, 0.2, 0.2, BCEngineMCMC::kMedium); }
-    if (E0 >2000)             { fitter.Fit(fit_name, {E0}, {low_edge, upp_edge}, std::kFlat, 0.2, 0.2, BCEngineMCMC::kMedium); }
+    if (E0 <= 500)            { fitter.Fit(fit_name, {E0}, {low_edge, upp_edge}, std::kQuadratic, 0, 0, BCEngineMCMC::kMedium); }
+    if (E0 > 500 && E0<=2000) { fitter.Fit(fit_name, {E0}, {low_edge, upp_edge}, std::kLinear, 0, 0, BCEngineMCMC::kMedium); }
+    if (E0 >2000)             { fitter.Fit(fit_name, {E0}, {low_edge, upp_edge}, std::kFlat, 0, 0, BCEngineMCMC::kMedium); }
   }
 }
 

--- a/src/get_resolution.py
+++ b/src/get_resolution.py
@@ -7,9 +7,11 @@ from legendmeta import JsonDB
 from legendmeta import LegendMetadata
 lmeta = LegendMetadata()
 
-operation ='ecal'
+# operation ='ecal'
+operation ='partition_ecal'
 par ='cuspEmax_ctc_cal'
-pars = 'eres_pars'
+# pars = 'eres_pars'
+pars = 'eres_linear'
 
 def get_resolution(config_file, detectors):
     # retrieve useful info
@@ -73,18 +75,21 @@ def get_resolution(config_file, detectors):
 
                 #get resolution
                 c="ch"+str(channel_map[d]['daq']['rawid'])
-                path_resolutions = os.path.join(info[0], info[4], "generated/par/hit/cal", p, r)
-                file= [file for file in os.listdir(path_resolutions) if file.endswith("results.json")]
+                # path_resolutions = os.path.join(info[0], info[4], "generated/par/hit/cal", p, r)
+                path_resolutions = os.path.join(info[0], info[4], "generated/par/pht/cal", p, r)
+                file = [file for file in os.listdir(path_resolutions) if file.endswith(".json")]
                 with open(os.path.join(path_resolutions, file[0]), "r") as file:
                     resolution_det = json.load(file)
-                    res_det = resolution_det[c][operation][par][pars]
+                    res_det = resolution_det[c]["results"][operation][par][pars]["parameters"]
                 resolution_list.append(res_det)
 
 
     #get the lists of the two resolution parameters
     if resolution_list != []:
-        a = np.take(resolution_list,0,1)
-        b = np.take(resolution_list,1,1)
+        # a = np.take(resolution_list,0,1)
+        # b = np.take(resolution_list,1,1)
+        a = np.array([float(dictionary["a"]) for dictionary in resolution_list])
+        b = np.array([float(dictionary["b"]) for dictionary in resolution_list])
     else:
         return [None, None]
 

--- a/src/main.py
+++ b/src/main.py
@@ -99,9 +99,9 @@ def main():
     logger_expo.debug("...inspected!")
     
     #check version set by the user
-    versions_avail = ["v01.05", "v01.06"]
+    versions_avail = ["v01.05", "v01.06", "v02.00"]
     if not info[4] in versions_avail:
-        logger_expo.debug(f"{info[4]} is not an available version. Try among '[v01.05, v01.06]'")
+        logger_expo.debug(f"{info[4]} is not an available version. Try among '[v01.05, v01.06, v02.00]'")
         return
         
     #check cut set by the user


### PR DESCRIPTION
Main changes:
- check over posteriors obtained for peak search analysis; if a posterior is truncated, there is a loop that enlarges the prior range until the posterior pdf is well [*] contained in it (* we look at the ratio of first 5% and last 5% wrt global mode content and see if it is bigger than 10%; if so, the bin content of left/right edges of the posterior pdf are sufficiently low to not have an impact on the extraction of quantiles)
- these checks are enabled just for the peak search analysis; a default value `{1,1,1,1}` for prior ranges is used for K lines and gamma analyses
- these checks work for flat/linear/quadratic bkgs (not for kStep bkg)
- these checks work for one fitted line only (es if we include more lines in the fit window, we only check priors/posteriors of the first line, ie the signal line at the energy at which we are fitting)
- one json file in output for each inspected energy (I left the 'old' piece to write in the same json file, but was randomly giving problems sometimes appending additional `}}` at the eof...). In this way, if an analysis has to be repeated, we can left unchanged the rest