### PR TITLE
intensity peak prior fixes + check on existence of root files

### DIFF
--- a/src/gamma-fitter/GammaLineFit.cxx
+++ b/src/gamma-fitter/GammaLineFit.cxx
@@ -68,6 +68,7 @@ int GammaLineFit::Fit( vector<double> lines, pair<double,double> range, std::vec
   fFitHist->Fit(fFitFunction,"RL");
 
   //! set parameter ranges using preliminaries
+  //--- bkg contributions
   for(int i=0;i<nBkgPars;i++) {
     int N_prior_bkg = 1;
     if ( backgroundType!=kStep ) { N_prior_bkg = rangePrior.at(i); }
@@ -75,6 +76,7 @@ int GammaLineFit::Fit( vector<double> lines, pair<double,double> range, std::vec
       (fBkgFunction->GetParameter(i)-N_prior_bkg*4*fBkgFunction->GetParError(i))/binning, 
       (fBkgFunction->GetParameter(i)+N_prior_bkg*4*fBkgFunction->GetParError(i))/binning);
   }
+  //--- lines contributions
   for(unsigned int i=0;i<lines.size();i++) {
     // enlarge just intensity of gamma line (this works only when inspecting a single gamma line)
     int N_prior = 1;
@@ -89,7 +91,7 @@ int GammaLineFit::Fit( vector<double> lines, pair<double,double> range, std::vec
      fRes->Eval(lines.at(i))+fwhmPrior*3 );
     // ... peak intensity
     fFitFunction->SetParLimits(nBkgPars+3*i+2, //preliminary parameters +-N_prior*4*uncertainty
-     max(0., (fFitFunction->GetParameter(nBkgPars+3*i+2)-4*N_prior*fFitFunction->GetParError(nBkgPars+3*i+2))/binning),
+     0,//max(0., (fFitFunction->GetParameter(nBkgPars+3*i+2)-4*N_prior*fFitFunction->GetParError(nBkgPars+3*i+2))/binning),
      (fFitFunction->GetParameter(nBkgPars+3*i+2)+4*N_prior*fFitFunction->GetParError(nBkgPars+3*i+2))/binning); 
   }
 

--- a/src/gamma-fitter/GammaLineFit.cxx
+++ b/src/gamma-fitter/GammaLineFit.cxx
@@ -89,10 +89,8 @@ int GammaLineFit::Fit( vector<double> lines, pair<double,double> range, std::vec
      fRes->Eval(lines.at(i))+fwhmPrior*3 );
     // ... peak intensity
     fFitFunction->SetParLimits(nBkgPars+3*i+2, //preliminary parameters +-N_prior*4*uncertainty
-     N_prior*max(0.,(fFitFunction->GetParameter(nBkgPars+3*i+2)-
-     4*fFitFunction->GetParError(nBkgPars+3*i+2))/binning),
-     N_prior*(fFitFunction->GetParameter(nBkgPars+3*i+2)+
-     4*fFitFunction->GetParError(nBkgPars+3*i+2))/binning); 
+     max(0., (fFitFunction->GetParameter(nBkgPars+3*i+2)-4*N_prior*fFitFunction->GetParError(nBkgPars+3*i+2))/binning),
+     (fFitFunction->GetParameter(nBkgPars+3*i+2)+4*N_prior*fFitFunction->GetParError(nBkgPars+3*i+2))/binning); 
   }
 
   //! create hist fitter and set priors

--- a/src/main.py
+++ b/src/main.py
@@ -71,6 +71,9 @@ def get_histo(gamma_src_code, histo_folder, version, result_dict, detectors, cut
     for p in result_dict.keys():
         for r in result_dict[p]:
             file_histo = os.path.join(gamma_src_code, "src/root_files", histo_folder, f"{p}-{r}-{version}-spectra.root")
+            if not os.path.exists(file_histo):
+               logger_expo.error(f"{file_histo} is NOT present - exit here.")
+               return None
             file_root = ROOT.TFile(file_histo)
             histo =  file_root.Get(f"{cut}/{detectors}")
             histo.SetDirectory(0)
@@ -160,6 +163,9 @@ def main():
     
     outputDir = ROOT.TNamed("outputDir",output)        
     histo  = get_histo(gamma_src_code, histo_info[0], info[4], result_dict, histo_name, info[5])
+    if histo is None:
+       logger_debug.error("No ROOT files were found - no spectra to be fitted were generated - exit here.")
+       sys.exit()
     resolution = get_resolution(config_file, det_name)
     if resolution == [None, None]:
         logger_expo.error("Resolution is a=b=None - maybe det is not available? Exit here")


### PR DESCRIPTION
The prior for the intensity peak now is defined as positive:
``` c
fFitFunction->SetParLimits(nBkgPars+3*i+2, 0, (fFitFunction->GetParameter(nBkgPars+3*i+2)+4*N_prior*fFitFunction->GetParError(nBkgPars+3*i+2))/binning);
```

Before, it was looking for the maximum between zero and a number extracted from the pre-fit:
``` c
fFitFunction->SetParLimits(nBkgPars+3*i+2, max(0., (fFitFunction->GetParameter(nBkgPars+3*i+2)-4*N_prior*fFitFunction->GetParError(nBkgPars+3*i+2))/binning), (fFitFunction->GetParameter(nBkgPars+3*i+2)+4*N_prior*fFitFunction->GetParError(nBkgPars+3*i+2))/binning);
```
However, this was resulting in bad fits (truncated posteriors):
![image](https://github.com/sofia-calgaro/legend-gamma-lines-analysis/assets/77326044/92be191c-79e3-4c74-a26a-2b5ea2bf33fc)
![image](https://github.com/sofia-calgaro/legend-gamma-lines-analysis/assets/77326044/f098f374-fd57-45c7-8c6f-b9210a3d6fec)


With the positive prior, the very same fit looks like this:
![image](https://github.com/sofia-calgaro/legend-gamma-lines-analysis/assets/77326044/8a6a93f1-cd50-4030-bf5e-772d0d9d3180)
![image](https://github.com/sofia-calgaro/legend-gamma-lines-analysis/assets/77326044/c9fa5a22-eea7-4b74-a5e2-0ec7655a28dc)
