### PR TITLE
small fixes

### DIFF
--- a/src/get_resolution.py
+++ b/src/get_resolution.py
@@ -69,7 +69,6 @@ def get_resolution(config_file, detectors):
 
                 # get exposure
                 exp_det = exposure_det[p][r][d]
-                exposure_list.append(exp_det)
 
                 #get resolution
                 c="ch"+str(channel_map[d]['daq']['rawid'])
@@ -87,7 +86,9 @@ def get_resolution(config_file, detectors):
                 
                 if not np.isnan(res_det['a']) and not np.isnan(res_det['b']):
                     resolution_list.append(res_det)
-
+                    exposure_list.append(exp_det)
+                else:
+                    print("--- NaN entry ---")
 
     #get the lists of the two resolution parameters
     if resolution_list != []:

--- a/src/main.py
+++ b/src/main.py
@@ -72,13 +72,17 @@ def get_histo(gamma_src_code, histo_folder, version, result_dict, detectors, cut
         for r in result_dict[p]:
             file_histo = os.path.join(gamma_src_code, "src/root_files", histo_folder, f"{p}-{r}-{version}-spectra.root")
             if not os.path.exists(file_histo):
-               logger_expo.error(f"{file_histo} is NOT present - exit here.")
-               return None
+               logger_expo.error(f"{file_histo} is NOT present - continue")
+               continue
             file_root = ROOT.TFile(file_histo)
             histo =  file_root.Get(f"{cut}/{detectors}")
+            if not histo: 
+               file_root.Close()
+               continue
             histo.SetDirectory(0)
             file_root.Close()
             histo_list.push_back(histo)  
+
     histo_tot = histo_list.at(0)
     histo_tot.SetName("Spectrum")
     for i in range(1,histo_list.size()):
@@ -204,7 +208,6 @@ def main():
     b_res.Write()
     tmp_file.Close()
     logger_expo.debug(f'Created ROOT file to give to the fitter code as input in {tmp_file_name}')
-
 
     logger_expo.debug("EOF")
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -3,23 +3,22 @@ import json
 import numpy as np
 import ROOT
 
-def get_results(E0: float, output_path: str, significance: float):
-    E0 = str(round(float(E0),1))
-    json_file = os.path.join(output_path, f"histo.{E0}.json")
+def get_results(fit_name: str, output_path: str, significance: float):
+    json_file = os.path.join(output_path, f"histo.{fit_name}.json")
 
     with open(json_file, 'r') as file:
         my_json = json.load(file)
 
-    if "intensity0_in_cts" in my_json[E0]["fit_parameters"]["line"].keys():
-        gm = my_json[E0]["fit_parameters"]["line"]["intensity0_in_cts"]["mode"] 
-        E0_counts_L68 = my_json[E0]["fit_parameters"]["line"]["intensity0_in_cts"]["range_min"] 
-        E0_counts_U68 = my_json[E0]["fit_parameters"]["line"]["intensity0_in_cts"]["range_max"] 
-        E0_counts_U90 = my_json[E0]["fit_parameters"]["line"]["intensity0_in_cts"]["upper_limit"]
+    if "intensity0_in_cts" in my_json[fit_name]["fit_parameters"]["line"].keys():
+        gm = my_json[fit_name]["fit_parameters"]["line"]["intensity0_in_cts"]["mode"] 
+        E0_counts_L68 = my_json[fit_name]["fit_parameters"]["line"]["intensity0_in_cts"]["range_min"] 
+        E0_counts_U68 = my_json[fit_name]["fit_parameters"]["line"]["intensity0_in_cts"]["range_max"] 
+        E0_counts_U90 = my_json[fit_name]["fit_parameters"]["line"]["intensity0_in_cts"]["upper_limit"]
 
-        root_file = f"histo_marginalized.{E0}.root"
+        root_file = f"histo_marginalized.{fit_name}.root"
         file_root = ROOT.TFile.Open(os.path.join(output_path, root_file), "READ")
         if not os.path.join(output_path, root_file):
-            print(f"Error - ROOT file does not exist for energy {E0} - exit here.")
+            print(f"Error - ROOT file does not exist for {fit_name} - exit here.")
             return None, None, None
 
         h = file_root.Get("h1_histo_fitter_model_parameter_intensity0")


### PR DESCRIPTION
- in utils.py, now we can provide string in general (before, I was reasoning just in terms of float numbers - now, `name_fit` is simply the name of the line, eg `"K40_1461"`, or the name of the energy at which the generic peak search was done, eg. `"200.0"`)
- before, when a detector was not available for a given run, there was no check on existence of that detector in the selected ROOT file --> BAD! This resulted in skipping detectors that are good in other runs (eg V08682A). Now, we simply continue to iterate over different runs/periods