### PR TITLE
fixed ALL filling

### DIFF
--- a/src/get_histogram.py
+++ b/src/get_histogram.py
@@ -123,39 +123,42 @@ def make_histos(config_file: str | dict):
                 h_all = ROOT.TH1D('All', 'All', number_bins, hist_range[0], hist_range[1])
 
                 # loop over HPGe detectors
-                # for ch in tmp_data.sort_values(by = ["location", "position"]).channel_id.unique():
                 for ch in tmp_data.sort_values(by = ["location", "position"]).energy_id.unique():
 
                     # save name, string and position
-                    # ch_name = tmp_data[tmp_data.channel_id == ch].name.unique()[0]
-                    # ch_string = tmp_data[tmp_data.channel_id == ch].location.unique()[0]
-                    # ch_position = tmp_data[tmp_data.channel_id == ch].position.unique()[0]
                     ch_name = tmp_data[tmp_data.energy_id == ch].name.unique()[0]
                     ch_string = tmp_data[tmp_data.energy_id == ch].location.unique()[0]
                     ch_position = tmp_data[tmp_data.energy_id == ch].position.unique()[0]
 
                     # create histogram
                     h = ROOT.TH1D(f's{ch_string}-p{ch_position}-{ch_name}', f's{ch_string}-p{ch_position}-{ch_name}', number_bins, hist_range[0], hist_range[1])
-                
-                    # fill single channel histogram
-                    # for e in tmp_data[tmp_data.channel_id == ch].energy:
-                    for e in tmp_data[tmp_data.energy_id == ch].energy:
-                        h.Fill(e)
-                        if ch_name[0] == "B": h_bege.Fill(e)
-                        if ch_name[0] == "C": h_coax.Fill(e)
-                        if ch_name[0] == "V": h_icpc.Fill(e)
-                        if ch_name[0] == "P": h_ppc.Fill(e)
 
-                    # fill all channels (full array) histogram
-                    for e in tmp_data.energy:
+                    # fill single channel histogram
+                    for e in tmp_data[tmp_data.energy_id == ch].energy:
                         h_all.Fill(e)
-    
+                        h.Fill(e)
+                        if ch_name[:2] == "B0": 
+                            h_bege.Fill(e)
+                        if ch_name[:2] == "C0":  
+                            h_coax.Fill(e)
+                        if ch_name[:2] == "V0":  
+                            h_icpc.Fill(e)
+                        if ch_name[:2] == "P0":  
+                            h_ppc.Fill(e)
+
                     h.Write()
+                    h = None
                 
                 h_bege.Write()
                 h_coax.Write()
                 h_icpc.Write()
                 h_ppc.Write()
                 h_all.Write()
+
+                h_bege = None
+                h_coax = None
+                h_icpc = None
+                h_ppc = None
+                h_all = None
         
             myfile.Close()

--- a/src/utils.py
+++ b/src/utils.py
@@ -3,17 +3,17 @@ import json
 import numpy as np
 import ROOT
 
-def get_results(fit_name: str, output_path: str, significance: float):
+def get_results(fit_name: str, output_path: str, significance: float, no_line: int):
     json_file = os.path.join(output_path, f"histo.{fit_name}.json")
 
     with open(json_file, 'r') as file:
         my_json = json.load(file)
 
-    if "intensity0_in_cts" in my_json[fit_name]["fit_parameters"]["line"].keys():
-        gm = my_json[fit_name]["fit_parameters"]["line"]["intensity0_in_cts"]["mode"] 
-        E0_counts_L68 = my_json[fit_name]["fit_parameters"]["line"]["intensity0_in_cts"]["range_min"] 
-        E0_counts_U68 = my_json[fit_name]["fit_parameters"]["line"]["intensity0_in_cts"]["range_max"] 
-        E0_counts_U90 = my_json[fit_name]["fit_parameters"]["line"]["intensity0_in_cts"]["upper_limit"]
+    if f"intensity{no_line}_in_cts" in my_json[fit_name]["fit_parameters"]["line"].keys():
+        gm =            my_json[fit_name]["fit_parameters"]["line"][f"intensity{no_line}_in_cts"]["mode"] 
+        E0_counts_L68 = my_json[fit_name]["fit_parameters"]["line"][f"intensity{no_line}_in_cts"]["range_min"] 
+        E0_counts_U68 = my_json[fit_name]["fit_parameters"]["line"][f"intensity{no_line}_in_cts"]["range_max"] 
+        E0_counts_U90 = my_json[fit_name]["fit_parameters"]["line"][f"intensity{no_line}_in_cts"]["upper_limit"]
 
         root_file = f"histo_marginalized.{fit_name}.root"
         file_root = ROOT.TFile.Open(os.path.join(output_path, root_file), "READ")
@@ -21,8 +21,8 @@ def get_results(fit_name: str, output_path: str, significance: float):
             print(f"Error - ROOT file does not exist for {fit_name} - exit here.")
             return None, None, None
 
-        h = file_root.Get("h1_histo_fitter_model_parameter_intensity0")
-        h_clone = file_root.Get("h1_histo_fitter_model_parameter_intensity0")
+        h = file_root.Get(f"h1_histo_fitter_model_parameter_intensity{no_line}")
+        h_clone = file_root.Get(f"h1_histo_fitter_model_parameter_intensity{no_line}")
 
         binmax = h.GetMaximumBin()
         for k in range(0,h.GetNbinsX(),1):


### PR DESCRIPTION
There was a bug that filled "All" spectra more than necessary. 

With the new filling, we correctly retrieve the sum content given by BEGe+COAX+ICPC+PPC (example below obtained for p03-r000):
![image](https://github.com/sofia-calgaro/legend-gamma-lines-analysis/assets/77326044/2f341e1c-f0fa-4304-9f30-cc7b435863c7)

It was checked that BEGe,COAX,ICPC,PPC are correctly filled:
![image](https://github.com/sofia-calgaro/legend-gamma-lines-analysis/assets/77326044/39226a91-33e8-4eea-b014-31179d334163)

Note: when retrieving best fit (and errors), now you have to give in input `no_line` that is either 0 or 1. We use 0 when we fitted only one gamma, while we use 0 or 1 when we fitted two gammas and we want to retrieve results for one of the two fitted lines.